### PR TITLE
Add FastAPI backend for ISEN orders

### DIFF
--- a/isen_backend/Dockerfile
+++ b/isen_backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/isen_backend/README.md
+++ b/isen_backend/README.md
@@ -1,0 +1,34 @@
+# ISEN Backend
+
+This backend uses FastAPI and MySQL via SQLAlchemy to store orders from Shopee.
+A background scheduler runs every 30 minutes to pull new orders (mocked).
+
+## Environment Variables
+
+- `MYSQL_URL` – SQLAlchemy connection string for MySQL
+
+## Development
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+The scheduler starts automatically when the app runs.
+
+## Docker
+
+Build and run:
+
+```bash
+docker build -t isen-backend .
+docker run -e MYSQL_URL=... -p 8080:8080 isen-backend
+```
+
+## Streamlit Dashboard
+
+Run the dashboard connecting to the API:
+
+```bash
+streamlit run streamlit_app.py --server.port 8501
+```

--- a/isen_backend/isen/db.py
+++ b/isen_backend/isen/db.py
@@ -1,0 +1,10 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DB_URL = os.getenv('MYSQL_URL', 'mysql+pymysql://user:password@localhost:3306/isen')
+
+engine = create_engine(DB_URL)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()

--- a/isen_backend/isen/models.py
+++ b/isen_backend/isen/models.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Column, Integer, String, Float, Text, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from .db import Base
+from datetime import datetime
+
+class Product(Base):
+    __tablename__ = 'products'
+    id = Column(Integer, primary_key=True, index=True)
+    sku = Column(String(50), unique=True, index=True)
+    name = Column(String(255))
+    description = Column(Text)
+    price = Column(Float)
+    stock_quantity = Column(Integer)
+    platform = Column(String(50))
+
+class Order(Base):
+    __tablename__ = 'orders'
+    id = Column(Integer, primary_key=True, index=True)
+    order_id = Column(String(100), unique=True, index=True)
+    platform = Column(String(50))
+    customer_name = Column(String(255))
+    status = Column(String(50))
+    total_amount = Column(Float)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    items = relationship("OrderItem", back_populates="order")
+
+class OrderItem(Base):
+    __tablename__ = 'order_items'
+    id = Column(Integer, primary_key=True, index=True)
+    order_id = Column(Integer, ForeignKey('orders.id'))
+    product_id = Column(Integer, ForeignKey('products.id'))
+    quantity = Column(Integer)
+    price_per_unit = Column(Float)
+    order = relationship("Order", back_populates="items")
+    product = relationship("Product")

--- a/isen_backend/isen/shopee.py
+++ b/isen_backend/isen/shopee.py
@@ -1,0 +1,27 @@
+import hmac
+import hashlib
+import time
+import os
+from typing import List, Dict
+
+# Mock fetch from Shopee API
+def fetch_orders() -> List[Dict]:
+    # Placeholder: return a list of order dicts
+    now = int(time.time())
+    return [
+        {
+            'order_id': f'shopee_{now}',
+            'platform': 'shopee',
+            'customer_name': 'John Doe',
+            'status': 'NEW',
+            'total_amount': 100.0,
+            'items': [
+                {'sku': 'SKU1', 'quantity': 2, 'price': 50.0}
+            ]
+        }
+    ]
+
+def generate_signature(path: str, partner_id: str, timestamp: str, partner_key: str) -> str:
+    base_string = f"{partner_id}{path}{timestamp}"
+    sign = hmac.new(partner_key.encode(), base_string.encode(), hashlib.sha256).hexdigest()
+    return sign

--- a/isen_backend/isen/tasks.py
+++ b/isen_backend/isen/tasks.py
@@ -1,0 +1,40 @@
+from .db import SessionLocal
+from .models import Order, OrderItem, Product
+from .shopee import fetch_orders
+from sqlalchemy.orm import Session
+
+
+def insert_orders(session: Session, orders_data):
+    for order_data in orders_data:
+        if session.query(Order).filter_by(order_id=order_data['order_id']).first():
+            continue
+        order = Order(
+            order_id=order_data['order_id'],
+            platform=order_data['platform'],
+            customer_name=order_data['customer_name'],
+            status=order_data['status'],
+            total_amount=order_data['total_amount'],
+        )
+        session.add(order)
+        session.flush()  # to get order.id
+
+        for item in order_data.get('items', []):
+            product = session.query(Product).filter_by(sku=item['sku']).first()
+            product_id = product.id if product else None
+            order_item = OrderItem(
+                order_id=order.id,
+                product_id=product_id,
+                quantity=item['quantity'],
+                price_per_unit=item['price'],
+            )
+            session.add(order_item)
+    session.commit()
+
+
+def fetch_and_store_orders():
+    session = SessionLocal()
+    try:
+        orders = fetch_orders()
+        insert_orders(session, orders)
+    finally:
+        session.close()

--- a/isen_backend/main.py
+++ b/isen_backend/main.py
@@ -1,0 +1,77 @@
+import uvicorn
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+from apscheduler.schedulers.background import BackgroundScheduler
+from typing import List
+
+from isen.db import SessionLocal, Base, engine
+from isen.models import Order, OrderItem
+from isen.tasks import fetch_and_store_orders
+
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="ISEN Backend")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.get("/orders")
+def list_orders(db: Session = Depends(get_db)):
+    orders = db.query(Order).all()
+    results = []
+    for o in orders:
+        results.append({
+            'id': o.id,
+            'order_id': o.order_id,
+            'platform': o.platform,
+            'customer_name': o.customer_name,
+            'status': o.status,
+            'total_amount': o.total_amount,
+            'created_at': o.created_at,
+            'updated_at': o.updated_at,
+        })
+    return results
+
+
+@app.get("/orders/{order_id}")
+def get_order(order_id: int, db: Session = Depends(get_db)):
+    order = db.query(Order).filter_by(id=order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return {
+        'id': order.id,
+        'order_id': order.order_id,
+        'platform': order.platform,
+        'customer_name': order.customer_name,
+        'status': order.status,
+        'total_amount': order.total_amount,
+        'created_at': order.created_at,
+        'updated_at': order.updated_at,
+        'items': [
+            {
+                'id': item.id,
+                'product_id': item.product_id,
+                'quantity': item.quantity,
+                'price_per_unit': item.price_per_unit,
+            } for item in order.items
+        ]
+    }
+
+
+def start_scheduler():
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(fetch_and_store_orders, 'interval', minutes=30)
+    scheduler.start()
+
+
+start_scheduler()
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/isen_backend/requirements.txt
+++ b/isen_backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+SQLAlchemy
+pymysql
+apscheduler
+streamlit
+requests

--- a/isen_backend/streamlit_app.py
+++ b/isen_backend/streamlit_app.py
@@ -1,0 +1,27 @@
+import requests
+import streamlit as st
+
+API_URL = st.secrets.get('API_URL', 'http://localhost:8000')
+
+st.title('ISEN Orders Dashboard')
+
+status_filter = st.selectbox('Status', ['', 'NEW', 'SHIPPED', 'COMPLETED'])
+platform_filter = st.selectbox('Platform', ['', 'shopee'])
+
+params = {}
+
+orders = requests.get(f"{API_URL}/orders").json()
+
+if status_filter:
+    orders = [o for o in orders if o['status'] == status_filter]
+if platform_filter:
+    orders = [o for o in orders if o['platform'] == platform_filter]
+
+sort_key = st.selectbox('Sort by', ['created_at', 'total_amount'])
+orders = sorted(orders, key=lambda x: x[sort_key])
+
+for o in orders:
+    st.subheader(f"Order {o['order_id']} - {o['status']}")
+    st.write(o)
+    details = requests.get(f"{API_URL}/orders/{o['id']}").json()
+    st.write(details['items'])


### PR DESCRIPTION
## Summary
- set up FastAPI backend with MySQL via SQLAlchemy
- add models for products, orders and order items
- schedule Shopee order pulls every 30 minutes
- expose REST endpoints to list orders and view an order
- provide Streamlit dashboard
- include Dockerfile and usage docs

## Testing
- `python -m py_compile isen_backend/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686de28f39d8832197089b9312f15086